### PR TITLE
refactor!: Refactor outcomes and unwrap error APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `UnwrapError#cause` respects failure's `#exception`.
+
+### Changed
+
+- (BREAKING) `Base#failure` context must be given as keyword argument.
+- (BREAKING) `Failure#message` is no longer part of its `#context`.
+- (BREAKING) `Failure#exception` is no longer part of its `#context`.
+
 
 ## [0.2.0] - 2024-01-28
 
-## Added
+### Added
 
 - Generate default failure messages with
   [i18n](https://github.com/ruby-i18n/i18n).
@@ -18,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-01-27
 
-## Added
+### Added
 
 - Initial release.
 

--- a/lib/amazing_activist/base.rb
+++ b/lib/amazing_activist/base.rb
@@ -61,8 +61,8 @@ module AmazingActivist
     # @param code (see Outcome::Failure#initialize)
     # @param context (see Outcome::Failure#initialize)
     # @return [Outcome::Failure]
-    def failure(code, **context)
-      Outcome::Failure.new(code, activity: self, context: context)
+    def failure(code, message: nil, exception: nil, context: {})
+      Outcome::Failure.new(code, activity: self, message: message, exception: exception, context: context)
     end
   end
 end

--- a/lib/amazing_activist/outcome/failure.rb
+++ b/lib/amazing_activist/outcome/failure.rb
@@ -9,19 +9,26 @@ module AmazingActivist
       # @return [Symbol]
       attr_reader :code
 
-      # @return [AmazingActivist::Activity]
+      # @return [AmazingActivist::Base]
       attr_reader :activity
 
-      # @return [Hash{Symbol => Object}]
+      # @return [Exception, nil]
+      attr_reader :exception
+
+      # @return [Hash]
       attr_reader :context
 
       # @param code [#to_sym]
       # @param activity [AmazingActivist::Activity]
-      # @param context [Hash{Symbol => Object}]
-      def initialize(code, activity:, context:)
-        @code     = code.to_sym
-        @activity = activity
-        @context  = context
+      # @param message [#to_s, nil]
+      # @param exception [Exception, nil]
+      # @param context [Hash]
+      def initialize(code, activity:, message:, exception:, context:)
+        @code      = code.to_sym
+        @activity  = activity
+        @message   = message&.to_s
+        @exception = exception
+        @context   = context
       end
 
       # @return [true]
@@ -35,15 +42,15 @@ module AmazingActivist
       end
 
       # @api internal
-      # @return [Array<(:failure, Symbol, AmazingActivist::Activity, Hash{Symbol => Object})>]
+      # @return [Array]
       def deconstruct
-        [:failure, @code, @activity, @context]
+        [:failure, @code, @activity]
       end
 
       # @api internal
-      # @return [Hash{success: Object, activity: AmazingActivist::Activity}]
+      # @return [Hash]
       def deconstruct_keys(_)
-        { failure: @code, activity: @activity, context: @context }
+        { failure: @code, activity: @activity, message: message, exception: exception, context: context }
       end
 
       # @yieldparam self [self]
@@ -56,8 +63,11 @@ module AmazingActivist
         raise UnwrapError, self
       end
 
+      # Failure message.
+      #
+      # @return [String]
       def message
-        @context.fetch(:message) { Polyglot.new(@activity).message(@code, **context) }
+        @message || Polyglot.new(@activity).message(@code, **context)
       end
     end
   end

--- a/lib/amazing_activist/outcome/success.rb
+++ b/lib/amazing_activist/outcome/success.rb
@@ -3,11 +3,11 @@
 module AmazingActivist
   module Outcome
     class Success
-      # @return [AmazingActivist::Activity]
+      # @return [AmazingActivist::Base]
       attr_reader :activity
 
       # @param value [Object]
-      # @param activity [AmazingActivist::Activity]
+      # @param activity [AmazingActivist::Base]
       def initialize(value, activity:)
         @value    = value
         @activity = activity
@@ -24,13 +24,13 @@ module AmazingActivist
       end
 
       # @api internal
-      # @return [Array<(:success, Object, AmazingActivist::Activity)>]
+      # @return [Array]
       def deconstruct
         [:success, @value, @activity]
       end
 
       # @api internal
-      # @return [Hash{success: Object, activity: AmazingActivist::Activity}]
+      # @return [Hash]
       def deconstruct_keys(_)
         { success: @value, activity: @activity }
       end

--- a/lib/amazing_activist/unwrap_error.rb
+++ b/lib/amazing_activist/unwrap_error.rb
@@ -13,5 +13,10 @@ module AmazingActivist
 
       super(failure.message)
     end
+
+    # @return [Exception, nil]
+    def cause
+      @failure.exception || super
+    end
   end
 end

--- a/spec/amazing_activist/unwrap_error_spec.rb
+++ b/spec/amazing_activist/unwrap_error_spec.rb
@@ -3,8 +3,18 @@
 RSpec.describe AmazingActivist::UnwrapError do
   subject(:error) { described_class.new(failure) }
 
-  let(:failure)  { AmazingActivist::Outcome::Failure.new(:unknown, activity: activity, context: {}) }
-  let(:activity) { Pretty::DamnGoodActivity.new }
+  let(:activity)  { Pretty::DamnGoodActivity.new }
+  let(:exception) { nil }
+
+  let(:failure) do
+    AmazingActivist::Outcome::Failure.new(
+      :nope,
+      activity:  activity,
+      message:   nil,
+      exception: exception,
+      context:   {}
+    )
+  end
 
   describe "#failure" do
     subject { error.failure }
@@ -16,5 +26,49 @@ RSpec.describe AmazingActivist::UnwrapError do
     subject { error.message }
 
     it { is_expected.to eq failure.message }
+  end
+
+  describe "#cause" do
+    subject { error.cause }
+
+    it { is_expected.to be nil }
+
+    context "when there was original exception" do
+      let(:error) do
+        begin
+          raise original_exception
+        rescue StandardError
+          raise described_class, failure
+        end
+      rescue described_class => e
+        e
+      end
+
+      let(:original_exception) { StandardError.new("you shall not pass") }
+
+      it { is_expected.to be original_exception }
+    end
+
+    context "when failure has associated exception" do
+      let(:exception) { StandardError.new("go away") }
+
+      it { is_expected.to be exception }
+    end
+
+    context "when failure has associated exception, and there was original cause" do
+      let(:error) do
+        begin
+          raise original_exception
+        rescue StandardError
+          raise described_class, failure
+        end
+      rescue described_class => e
+        e
+      end
+
+      let(:exception) { StandardError.new("go away") }
+
+      it { is_expected.to be exception }
+    end
   end
 end


### PR DESCRIPTION
* Extract failure's `:message` and `:exception` into keywords
* Move `Base#failure` context into explicit keyyword
* Provide `UnwrapError#cause` based on failure's exception