### PR TITLE
refactor!: Keep activity suffix in i18n keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- (BREAKING) i18n does not remove `_activity` suffix from keys anymore, e.g.
+  for `Foo::BarActivity` expected i18n key will be `foo/bar_activity`, not
+  `foo/bar` as it was before.
+
 
 ## [0.4.0] - 2024-02-19
 

--- a/lib/amazing_activist/locale/en.yml
+++ b/lib/amazing_activist/locale/en.yml
@@ -1,4 +1,4 @@
 en:
   amazing_activist:
     failures:
-      not_implemented: "<%{activity}> activity has no implementation"
+      not_implemented: "<%{activity}> has no implementation"

--- a/lib/amazing_activist/locale/gl.yml
+++ b/lib/amazing_activist/locale/gl.yml
@@ -1,4 +1,4 @@
 gl:
   amazing_activist:
     failures:
-      not_implemented: "<%{activity}> actividade non ten implementación"
+      not_implemented: "<%{activity}> non ten implementación"

--- a/lib/amazing_activist/polyglot.rb
+++ b/lib/amazing_activist/polyglot.rb
@@ -10,9 +10,6 @@ I18n.load_path += Dir[File.expand_path("#{__dir__}/locale/*.yml")]
 module AmazingActivist
   # @api internal
   class Polyglot
-    ANONYMOUS_ACTIVITY_NAME = "anonymous"
-    private_constant :ANONYMOUS_ACTIVITY_NAME
-
     def initialize(activity)
       @activity = activity
     end
@@ -25,26 +22,26 @@ module AmazingActivist
     # Thus, if activity `Pretty::DamnGoodActivity` failed with `:bad_choise`
     # code the lookup will be:
     #
-    # * `amazing_activist.activities.pretty/damn_good.failures.bad_choice
+    # * `amazing_activist.activities.pretty/damn_good_activity.failures.bad_choice
     # * `amazing_activist.failures.bad_choice
     #
     # If there's no translation with any of the above keys, a generic
     # non-translated message will be used:
     #
-    #     <pretty/damn_good> activity failed - bad_choice
+    #     <pretty/damn_good_activity> failed - bad_choice
     #
     # @return [String] Failure message
     def message(code, **context)
       default = [
         :"amazing_activist.failures.#{code}",
-        "<%{activity}> activity failed - %{code}" # rubocop:disable Style/FormatStringToken
+        "<%{activity}> failed - %{code}" # rubocop:disable Style/FormatStringToken
       ]
 
       if @activity.class.name
-        activity = @activity.class.name.underscore.presence.delete_suffix("_activity")
+        activity = @activity.class.name.underscore.presence
         i18n_key = :"amazing_activist.activities.#{activity}.failures.#{code}"
       else
-        activity = "(anonymous)"
+        activity = "(anonymous activity)"
         i18n_key = default.shift
       end
 

--- a/spec/amazing_activist/polyglot_spec.rb
+++ b/spec/amazing_activist/polyglot_spec.rb
@@ -13,25 +13,25 @@ RSpec.describe AmazingActivist::Polyglot do
 
     around { |ex| I18n.with_locale(locale, &ex) }
 
-    it { is_expected.to eq "<pretty/damn_good> activity failed - blablabla" }
+    it { is_expected.to eq "<pretty/damn_good_activity> failed - blablabla" }
 
     context "when activity class name has no Activity suffix" do
       let(:activity) { Unconventional::ClassNaming.new }
 
-      it { is_expected.to eq "<unconventional/class_naming> activity failed - blablabla" }
+      it { is_expected.to eq "<unconventional/class_naming> failed - blablabla" }
     end
 
     context "when activity class is anonymous" do
       let(:activity) { Class.new(AmazingActivist::Base).new }
 
-      it { is_expected.to eq "<(anonymous)> activity failed - blablabla" }
+      it { is_expected.to eq "<(anonymous activity)> failed - blablabla" }
     end
 
     context "when there's generic failure message for selected locale" do
       let(:locale) { :gl }
       let(:code)   { :not_implemented }
 
-      it { is_expected.to eq "<pretty/damn_good> actividade non ten implementación" }
+      it { is_expected.to eq "<pretty/damn_good_activity> non ten implementación" }
     end
 
     context "when there's named failure message for given code" do

--- a/spec/support/locale/en.yml
+++ b/spec/support/locale/en.yml
@@ -1,7 +1,7 @@
 en:
   amazing_activist:
     activities:
-      pretty/damn_good:
+      pretty/damn_good_activity:
         failures:
           bad_choice: "Choose something else!"
     failures:


### PR DESCRIPTION
Magic deletion of `_activity` suffix leads to confusion and possible collisions.