### PR TITLE
Pass through blocks

### DIFF
--- a/lib/amazing_activist/irresistible.rb
+++ b/lib/amazing_activist/irresistible.rb
@@ -14,9 +14,9 @@ module AmazingActivist
     #
     # @see #initialize
     # @see #call
-    def call(...)
-      activity = new(...)
-      outcome  = irresistible_call(activity)
+    def call(*args, **kwargs, &block)
+      activity = new(*args, **kwargs)
+      outcome  = irresistible_call(activity, &block)
 
       unless outcome.is_a?(Outcome::Failure) || outcome.is_a?(Outcome::Success)
         return activity.instance_exec(outcome, &broken_contract_handler)
@@ -28,8 +28,8 @@ module AmazingActivist
     private
 
     # @api internal
-    def irresistible_call(activity)
-      activity.call
+    def irresistible_call(activity, &block)
+      activity.call(&block)
     rescue UnwrapError => e
       e.failure
     rescue Exception => e # rubocop:disable Lint/RescueException


### PR DESCRIPTION
Hello hello,
Let me know if this is something you're willing to add, here's the relevant usecase:
```ruby
# In Payments::CreateStripeCardPaymentActivity
def call
  card_payment = ActiveRecord::Base.transaction do
    card_payment = stripe_card.with_lock do
      stripe_card.card_payments.create!(
        amount_cents:,
        status:       'pending',
        user:
      )
    end

    yield card_payment if block_given?

    card_payment
  end

  stripe_payment_intent = Stripe::PaymentIntent.create(...)
  # ...
end
```
Usage:
```ruby
result = Payments::CreateStripeCardPaymentActivity.call(
  stripe_card:,
  amount_cents:,
) do |card_payment|
  insert_payments(card_payment)
end
# ...
def insert_payments(card_payment)
  purchasables.each do |purchasable|
    card_payment.payments.create!(
      amount_cents: purchasable.price_cents,
      purchasable:,
      payment_method:
    )
  end
end
```

  
      