### PR TITLE
feat: Use Literal gem for inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Use [literal](https://github.com/joeldrapper/literal) gem to aid inputs
+  boilerplate.
+
+### Changed
+
+- (BREAKING) Drop support of Ruby-3.0.X, and Ruby-3.1.X
+
 
 ## [0.6.0] - 2024-12-15
 

--- a/amazing-activist.gemspec
+++ b/amazing-activist.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport"
   spec.add_dependency "i18n"
+  spec.add_dependency "literal"
 end

--- a/lib/amazing_activist/base.rb
+++ b/lib/amazing_activist/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "literal"
-
 require_relative "./irresistible"
 require_relative "./outcome"
 
@@ -32,15 +30,6 @@ module AmazingActivist
   # ----
   class Base
     extend Irresistible
-    extend Literal::Properties
-
-    class << self
-      private
-
-      def prop(name, type, kind = :keyword, reader: :private, default: nil, &)
-        super(name, type, kind, reader:, writer: false, predicate: false, default:, &)
-      end
-    end
 
     prop :params, _Hash(Symbol, _Any?), :**
 

--- a/lib/amazing_activist/base.rb
+++ b/lib/amazing_activist/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "literal"
+
 require_relative "./irresistible"
 require_relative "./outcome"
 
@@ -30,11 +32,9 @@ module AmazingActivist
   # ----
   class Base
     extend Irresistible
+    extend Literal::Properties
 
-    # @param params [Hash{Symbol => Object}]
-    def initialize(**params)
-      @params = params
-    end
+    prop :params, _Hash(Symbol, _Any?), :**, reader: :private, writer: false
 
     # @return [Outcome::Success, Outcome::Failure]
     def call
@@ -42,9 +42,6 @@ module AmazingActivist
     end
 
     private
-
-    # @return [Hash{Symbol => Object}]
-    attr_reader :params
 
     # @param value (see Outcome::Success#initialize)
     # @return [Outcome::Success]

--- a/lib/amazing_activist/base.rb
+++ b/lib/amazing_activist/base.rb
@@ -34,7 +34,15 @@ module AmazingActivist
     extend Irresistible
     extend Literal::Properties
 
-    prop :params, _Hash(Symbol, _Any?), :**, reader: :private, writer: false
+    class << self
+      private
+
+      def prop(name, type, kind = :keyword, reader: :private, default: nil, &)
+        super(name, type, kind, reader:, writer: false, predicate: false, default:, &)
+      end
+    end
+
+    prop :params, _Hash(Symbol, _Any?), :**
 
     # @return [Outcome::Success, Outcome::Failure]
     def call

--- a/lib/amazing_activist/contractable.rb
+++ b/lib/amazing_activist/contractable.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "literal"
+
 require_relative "./broken_contract_error"
 
 module AmazingActivist
   module Contractable
+    include Literal::Properties
+
     DEFAULT_BROKEN_OUTCOME_HANDLER = lambda do |outcome|
       raise BrokenContractError, "#{self.class}#call returned #{outcome.class} instead of Outcome"
     end
@@ -25,6 +29,10 @@ module AmazingActivist
     end
 
     private
+
+    def prop(name, type, kind = :keyword, reader: :private, default: nil, &)
+      super(name, type, kind, reader:, writer: false, predicate: false, default:, &)
+    end
 
     def on_broken_outcome(&block)
       raise ArgumentError, "Handler block required." unless block

--- a/spec/amazing_activist/contractable_spec.rb
+++ b/spec/amazing_activist/contractable_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe AmazingActivist::Contractable do
+  it "allows specifying input arguments" do
+    expect(Pretty::ParameterizedActivity.call(code: :foo))
+      .to be_an(AmazingActivist::Outcome::Success)
+      .and have_attributes(unwrap!: { code: :foo, name: nil, params: {} })
+
+    expect(Pretty::ParameterizedActivity.call(code: :foo, name: "bar", answer: 42))
+      .to be_an(AmazingActivist::Outcome::Success)
+      .and have_attributes(unwrap!: { code: :foo, name: "bar", params: { answer: 42 } })
+  end
+
+  it "allows overriding parent input arguments" do
+    expect(Pretty::InheritedParameterizedActivity.call(params: 42))
+      .to be_an(AmazingActivist::Outcome::Success)
+      .and have_attributes(unwrap!: { code: nil, name: nil, params: 42 })
+
+    # TODO: Provide configurable behaviour upon invalid input
+    expect { Pretty::InheritedParameterizedActivity.call(oopsie: 42) }
+      .to raise_error(ArgumentError, %r{oopsie})
+  end
+end

--- a/spec/support/amazing_activist.rb
+++ b/spec/support/amazing_activist.rb
@@ -68,6 +68,20 @@ module Pretty
       end
     end
   end
+
+  class ParameterizedActivity < AmazingActivist::Base
+    prop :code, Symbol
+    prop :name, _String?
+
+    def call
+      success({ code:, name:, params: })
+    end
+  end
+
+  class InheritedParameterizedActivity < ParameterizedActivity
+    prop :code, _Any?
+    prop :params, _Any?
+  end
 end
 
 class YetAnotherActivity < Pretty::DamnGoodActivity; end


### PR DESCRIPTION
This will allow to define expected params much easier, while defaults will still allow **params:

``` ruby
  class Example < AmazingActivist::Base
    prop :email, String

    def call
      success({ email: email, params: params })
    end
  end

  Example.call(email: "john.doe@example.com", full_name: "John Doe")
  # => Success({ email: "...", params: { full_name: "..." } })
```

Related-To: https://github.com/ixti/amazing-activist/issues/27