### PR TITLE
feat: Disallow `A.new(...).call`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- (BREAKING) Prohibit `AmazingActivist::Base#new` calls. All activities must be
+  called via `.call`, i.e. `A.call(...)` instead of `A.new(...).call`.
+
 
 ## [0.7.0] - 2025-04-14
 

--- a/lib/amazing_activist/base.rb
+++ b/lib/amazing_activist/base.rb
@@ -31,6 +31,11 @@ module AmazingActivist
   class Base
     extend Irresistible
 
+    class << self
+      # Prohibit `Activity.new(...).call` style, as it makes activist not much `Irresistable`
+      private :new
+    end
+
     prop :params, _Hash(Symbol, _Any?), :**
 
     # @return [Outcome::Success, Outcome::Failure]

--- a/lib/amazing_activist/irresistible.rb
+++ b/lib/amazing_activist/irresistible.rb
@@ -12,7 +12,6 @@ module AmazingActivist
 
     # Initialize and call activity.
     #
-    # @see #initialize
     # @see #call
     def call(...)
       activity = new(...)

--- a/spec/amazing_activist/base_spec.rb
+++ b/spec/amazing_activist/base_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AmazingActivist::Base do
 
   describe ".call" do
     it "delegates execution to #call" do
-      activity = Pretty::DamnGoodActivity.new
+      activity = Pretty::DamnGoodActivity.__send__(:new)
 
       allow(Pretty::DamnGoodActivity).to receive(:new).and_return(activity)
       allow(activity).to receive(:call).and_call_original

--- a/spec/amazing_activist/outcome/failure_spec.rb
+++ b/spec/amazing_activist/outcome/failure_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AmazingActivist::Outcome::Failure do
   end
 
   let(:code)            { :you_shall_not_pass }
-  let(:activity)        { Pretty::DamnGoodActivity.new }
+  let(:activity)        { Pretty::DamnGoodActivity.allocate }
   let(:message)         { nil }
   let(:exception)       { StandardError.new("nope") }
   let(:failure_context) { { name: "Barlog" } }

--- a/spec/amazing_activist/outcome/success_spec.rb
+++ b/spec/amazing_activist/outcome/success_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AmazingActivist::Outcome::Success do
   subject(:outcome) { described_class.new(value, activity: activity) }
 
   let(:value)    { :dobby_is_free }
-  let(:activity) { Pretty::DamnGoodActivity.new }
+  let(:activity) { Pretty::DamnGoodActivity.allocate }
 
   describe "#inspect" do
     subject { outcome.inspect }

--- a/spec/amazing_activist/polyglot_spec.rb
+++ b/spec/amazing_activist/polyglot_spec.rb
@@ -9,20 +9,20 @@ RSpec.describe AmazingActivist::Polyglot do
     let(:locale)          { :en }
     let(:code)            { :blablabla }
     let(:failure_context) { {} }
-    let(:activity)        { Pretty::DamnGoodActivity.new }
+    let(:activity)        { Pretty::DamnGoodActivity.allocate }
 
     around { |ex| I18n.with_locale(locale, &ex) }
 
     it { is_expected.to eq "<pretty/damn_good_activity> failed - blablabla" }
 
     context "when activity class name has no Activity suffix" do
-      let(:activity) { Unconventional::ClassNaming.new }
+      let(:activity) { Unconventional::ClassNaming.allocate }
 
       it { is_expected.to eq "<unconventional/class_naming> failed - blablabla" }
     end
 
     context "when activity class is anonymous" do
-      let(:activity) { Class.new(AmazingActivist::Base).new }
+      let(:activity) { Class.new(AmazingActivist::Base).allocate }
 
       it { is_expected.to eq "<(anonymous activity)> failed - blablabla" }
     end
@@ -41,7 +41,7 @@ RSpec.describe AmazingActivist::Polyglot do
     end
 
     context "when translation key has no `amazing_activist.` scope" do
-      let(:activity) { YetAnotherActivity.new }
+      let(:activity) { YetAnotherActivity.allocate }
       let(:code)     { :bad_choice }
 
       it { is_expected.to eq "I repeat! Choose something else!" }

--- a/spec/amazing_activist/unwrap_error_spec.rb
+++ b/spec/amazing_activist/unwrap_error_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe AmazingActivist::UnwrapError do
   subject(:error) { described_class.new(failure) }
 
-  let(:activity)  { Pretty::DamnGoodActivity.new }
+  let(:activity)  { Pretty::DamnGoodActivity.allocate }
   let(:exception) { nil }
 
   let(:failure) do


### PR DESCRIPTION
Activities are objectified units of work, thus `.call(...)` is more commonly used approcah. In addition `A.new(...).call` is somewhat confusing and adds extra burden on the reader.

* Is it possible to call `#call` more than once?
  * The answer depends on the implementation of the activity.
* Does it behave same as `.call`?
  * The answer is no, as it will bypass `on_error`, and `on_broken_contract` handlers completely.