### PR TITLE
refactor!: Don't provide default catch-all params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (BREAKING) Prohibit `AmazingActivist::Base#new` calls. All activities must be
   called via `.call`, i.e. `A.call(...)` instead of `A.new(...).call`.
 
+### Removed
+
+- (BREAKING) Don't provide default catch-all `params` prop.
+
 
 ## [0.7.0] - 2025-04-14
 

--- a/lib/amazing_activist/base.rb
+++ b/lib/amazing_activist/base.rb
@@ -11,6 +11,8 @@ module AmazingActivist
   # [source,ruby]
   # ----
   # class OnboardActivity < AmazingActivist::Base
+  #   prop :params, _Hash(Symbol, _Any?), :**
+  #
   #   def call
   #     user = User.new(params)
   #
@@ -35,8 +37,6 @@ module AmazingActivist
       # Prohibit `Activity.new(...).call` style, as it makes activist not much `Irresistable`
       private :new
     end
-
-    prop :params, _Hash(Symbol, _Any?), :**
 
     # @return [Outcome::Success, Outcome::Failure]
     def call

--- a/spec/amazing_activist/base_spec.rb
+++ b/spec/amazing_activist/base_spec.rb
@@ -109,11 +109,11 @@ RSpec.describe AmazingActivist::Base do
           exception: an_instance_of(RuntimeError)
         )
 
-      expect(activity_class.call(error_class: NotImplementedError))
+      expect(activity_class.call(error_class: SyntaxError))
         .to be_failure
         .and have_attributes(
           code:      :unhandled_exception,
-          exception: an_instance_of(NotImplementedError)
+          exception: an_instance_of(SyntaxError)
         )
     end
 

--- a/spec/amazing_activist/contractable_spec.rb
+++ b/spec/amazing_activist/contractable_spec.rb
@@ -2,22 +2,30 @@
 
 RSpec.describe AmazingActivist::Contractable do
   it "allows specifying input arguments" do
-    expect(Pretty::ParameterizedActivity.call(code: :foo))
+    expect(Pretty::ParameterizedActivity.call(code: :foo, name: "bar"))
       .to be_an(AmazingActivist::Outcome::Success)
-      .and have_attributes(unwrap!: { code: :foo, name: nil, params: {} })
+      .and have_attributes(unwrap!: { code: :foo, name: "bar" })
 
-    expect(Pretty::ParameterizedActivity.call(code: :foo, name: "bar", answer: 42))
-      .to be_an(AmazingActivist::Outcome::Success)
-      .and have_attributes(unwrap!: { code: :foo, name: "bar", params: { answer: 42 } })
+    # TODO: Provide configurable behaviour upon invalid input
+    expect { Pretty::ParameterizedActivity.call }
+      .to raise_error(ArgumentError, %r{:code})
+
+    # TODO: Provide configurable behaviour upon invalid input
+    expect { Pretty::ParameterizedActivity.call(code: :foo, oopsie: 42) }
+      .to raise_error(ArgumentError, %r{:oopsie})
   end
 
   it "allows overriding parent input arguments" do
-    expect(Pretty::InheritedParameterizedActivity.call(params: 42))
+    expect(Pretty::InheritedParameterizedActivity.call(code: 42, name: "foo", details: "bar"))
       .to be_an(AmazingActivist::Outcome::Success)
-      .and have_attributes(unwrap!: { code: nil, name: nil, params: 42 })
+      .and have_attributes(unwrap!: { code: 42, name: "foo", details: "bar" })
 
     # TODO: Provide configurable behaviour upon invalid input
-    expect { Pretty::InheritedParameterizedActivity.call(oopsie: 42) }
-      .to raise_error(ArgumentError, %r{oopsie})
+    expect { Pretty::InheritedParameterizedActivity.call }
+      .to raise_error(ArgumentError, %r{:code, :details})
+
+    # TODO: Provide configurable behaviour upon invalid input
+    expect { Pretty::InheritedParameterizedActivity.call(code: 42, details: "bar", oopsie: 42) }
+      .to raise_error(ArgumentError, %r{:oopsie})
   end
 end

--- a/spec/support/amazing_activist.rb
+++ b/spec/support/amazing_activist.rb
@@ -35,13 +35,17 @@ class UnhandledExceptionActivity < AmazingActivist::Base
     end
   end
 
+  prop :error_class, _Class(Exception), default: -> { RuntimeError }
+
   def call
-    raise params.fetch(:error_class, RuntimeError), "Boom!"
+    raise error_class, "Boom!"
   end
 end
 
 module Pretty
   class DamnGoodActivity < AmazingActivist::Base
+    prop :params, _Hash(Symbol, _Any?), :**
+
     def call
       if :go_to_the_punk_rock_show == params[:what_do_you_want_to_do_today?]
         success("YEAH! Let's go to the punk rock show!")
@@ -52,6 +56,8 @@ module Pretty
   end
 
   class IrresistibleActivity < AmazingActivist::Base
+    prop :proposal, _Any?
+
     def call
       propose.unwrap!
       success
@@ -60,7 +66,7 @@ module Pretty
     private
 
     def propose
-      case params[:proposal]
+      case proposal
       when :watch_tv_and_have_a_couple_of_brews
         failure(:you_can_do_better)
       else
@@ -74,13 +80,17 @@ module Pretty
     prop :name, _String?
 
     def call
-      success({ code:, name:, params: })
+      success({ code:, name: })
     end
   end
 
   class InheritedParameterizedActivity < ParameterizedActivity
-    prop :code, _Any?
-    prop :params, _Any?
+    prop :code,    Integer
+    prop :details, String
+
+    def call
+      success({ code:, name:, details: })
+    end
   end
 end
 


### PR DESCRIPTION
With this change, for backward-compatibility, users will have to manually add:

``` ruby
class ApplicationActivity < AmazingActivist::Base
  prop :params, _Hash(Symbol, _Any?), :**
end
```

### Rationale

It's counter-intuitive when activity fails on wrong type, but silently swallows unexpected keyword arguments (e.g. mistyped):

``` ruby
class Example < AmazingActivist::Base
  prop :name, _String?
end

Example.call(nane: "not very intuitive")
```