### PR TITLE
feat: Alias value_or to success_or

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `success_or` alias for `value_or`
+
 
 ## [0.9.0] - 2025-05-28
 

--- a/lib/amazing_activist/failure.rb
+++ b/lib/amazing_activist/failure.rb
@@ -6,7 +6,7 @@ module AmazingActivist
 
     # @!attribute [r] failure
     #   @return failure [Symbol]
-    prop :failure, _Interface(:to_sym), :positional, &:to_sym
+    prop :code, _Interface(:to_sym), :positional, &:to_sym
 
     # @!attribute [r] activity
     #   @return [AmazingActivist::Base]
@@ -22,23 +22,22 @@ module AmazingActivist
 
     prop :message, _String?, reader: false
 
-    def code     = failure
-    def success? = false
     def failure? = true
+    def success? = false
 
     # @api internal
     # @return [Array]
     def deconstruct
-      [:failure, failure, activity]
+      [:failure, code, activity]
     end
 
     # @api internal
     # @return [Hash]
     def deconstruct_keys(keys)
       if keys.nil? || keys.include?(:message)
-        { failure:, activity:, exception:, context:, message: }
+        { failure: code, activity:, exception:, context:, message: }
       else
-        { failure:, activity:, exception:, context: }
+        { failure: code, activity:, exception:, context: }
       end
     end
 
@@ -46,7 +45,7 @@ module AmazingActivist
     #
     # @return [String]
     def message
-      @message || Polyglot.new(activity).message(failure, **context)
+      @message || Polyglot.new(activity).message(code, **context)
     end
   end
 end

--- a/lib/amazing_activist/outcome.rb
+++ b/lib/amazing_activist/outcome.rb
@@ -27,11 +27,11 @@ module AmazingActivist
       if block_given?
         warn "block supersedes default value argument" unless default == UNDEFINED
 
-        return success if success?
+        return value if success?
 
         yield self
       elsif default != UNDEFINED
-        return success if success?
+        return value if success?
 
         default
       else
@@ -39,10 +39,12 @@ module AmazingActivist
       end
     end
 
+    alias success_or value_or
+
     # @return [Object] {#success} if outcome is {Success}
     # @raise [UnwrapError] otherwise
     def unwrap!
-      return success if success?
+      return value if success?
 
       raise UnwrapError, self
     end

--- a/lib/amazing_activist/success.rb
+++ b/lib/amazing_activist/success.rb
@@ -6,26 +6,25 @@ module AmazingActivist
 
     # @!attribute [r] success
     #   @return [AmazingActivist::Base]
-    prop :success, _Any?, :positional
+    prop :value, _Any?, :positional
 
     # @!attribute [r] activity
     #   @return [AmazingActivist::Base]
     prop :activity, AmazingActivist::Base
 
-    def value    = success
-    def success? = true
     def failure? = false
+    def success? = true
 
     # @api internal
     # @return [Array]
     def deconstruct
-      [:success, success, activity]
+      [:success, value, activity]
     end
 
     # @api internal
     # @return [Hash]
     def deconstruct_keys(_)
-      { success:, activity: }
+      { success: value, activity: }
     end
   end
 end

--- a/spec/amazing_activist/failure_spec.rb
+++ b/spec/amazing_activist/failure_spec.rb
@@ -137,4 +137,10 @@ RSpec.describe AmazingActivist::Failure do
 
     it { is_expected.to be exception }
   end
+
+  describe "#success_or" do
+    it "is an alias of #value_or" do
+      expect(outcome.method(:success_or)).to eq(outcome.method(:value_or))
+    end
+  end
 end

--- a/spec/amazing_activist/success_spec.rb
+++ b/spec/amazing_activist/success_spec.rb
@@ -86,4 +86,10 @@ RSpec.describe AmazingActivist::Success do
       end
     end
   end
+
+  describe "#success_or" do
+    it "is an alias of #value_or" do
+      expect(outcome.method(:success_or)).to eq(outcome.method(:value_or))
+    end
+  end
 end


### PR DESCRIPTION
Allows semantically looking code:

    def call
      AnotherActivity.call(...).success_or { return it }

      # other steps in case previous was a success
    end